### PR TITLE
add mbstring extension for php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "The Capital Farm Server provides API access to Capital Farm Client (CFC) which is a portal for Food Producers, Farmers, Farm Equipment and Products Sellers or Leasers, Food Products Market Players, Land Owners, and Investors. The portal provides a central point where food producers can find all in one service and products to improve and increase production, expedite and grow their food production business.",
     "require-dev": {
         "phpunit/phpunit": "^9.1",
-        "friendsofphp/php-cs-fixer": "^2.0"
+        "friendsofphp/php-cs-fixer": "^2.0",
+        "ext-mbstring": "*"
     },
     "require": {},
     "scripts": {


### PR DESCRIPTION
## Description
Resolve heroku deploy error requiring ext-mbstring extension

Fixes no issue

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
